### PR TITLE
Use docker and docker-compose clients directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY requirements.txt /tmp/
 # Because we're using Alpine we need to get most of the native dependencies
 # from the Alpine package manager.
 RUN apk update && apk add \
+    docker \
     bash \
     curl \
     nodejs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk update && apk add \
     py-cffi \
     py-paramiko \
     && pip install -r /tmp/requirements.txt \
+    && npm install -g triton json \
     && apk del build-base \
     && rm -rf /var/cache/apk/*
 

--- a/testcases.py
+++ b/testcases.py
@@ -43,23 +43,6 @@ class ClientException(Exception):
     """
     pass
 
-def debug(fn):
-    """
-    Function/method decorator to trace calls via debug logging.
-    Is a pass-thru if we're not at LOG_LEVEL=DEBUG. Normally this
-    would have a lot of perf impact but this application doesn't
-    have significant throughput.
-    """
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        # magic number 10 == roughly top of stack for this module
-        name = '{}{}'.format(((len(inspect.stack())-10) * " "), fn.__name__)
-        log.debug('%s: %s, %s' % (name, args, kwargs))
-        out = apply(fn, args, kwargs)
-        log.debug('%s: %s' % (name, str(out)[:50]))
-        return out
-    return wrapper
-
 def dump_environment_to_file(filepath):
     """
     Takes the container's environment and dumps it out to a file
@@ -120,7 +103,6 @@ class AutopilotPatternTest(unittest.TestCase):
             return child_tearDown(self, *args, **kwargs)
         cls.tearDown = tearDown_override
 
-    @debug
     def _setUp(self):
         """
         AutopilotPatternTest._setUp will be called after a subclass's
@@ -131,7 +113,6 @@ class AutopilotPatternTest(unittest.TestCase):
         self.compose('up', '-d')
         self.wait_for_containers()
 
-    @debug
     def _tearDown(self):
         """
         AutopilotPatternTest._tearDown will be called before a subclass's
@@ -241,7 +222,6 @@ class AutopilotPatternTest(unittest.TestCase):
         except subprocess.CalledProcessError as ex:
             raise ClientException(ex)
 
-    @debug
     def compose_ps(self, service_name=None, verbose=False):
         """
         Runs `docker-compose ps`, filtered by `service_name` and dumping
@@ -283,7 +263,6 @@ class AutopilotPatternTest(unittest.TestCase):
         return [re.sub('\. ', '.', re.sub('  +', ' ', field).strip())
                 for field in output]
 
-    @debug
     def compose_scale(self, service_name, count, verbose=False):
         """
         Runs `docker-compose scale <service>=<count>`, dumping
@@ -292,7 +271,6 @@ class AutopilotPatternTest(unittest.TestCase):
         self.compose('scale',
                      '{}={}'.format(service_name, count), verbose=verbose)
 
-    @debug
     def docker_exec(self, container, command_line, verbose=False):
         """
         Runs `docker exec <command_line>` on the container and
@@ -303,13 +281,11 @@ class AutopilotPatternTest(unittest.TestCase):
         args = ['exec', name] + command_line.split()
         return self.docker(*args, verbose=verbose)
 
-    @debug
     def docker_stop(self, container, verbose=False):
         """ Stops a specific instance. """
         name = self.get_container_name(container)
         output = self.docker('stop', name, verbose=verbose)
 
-    @debug
     def docker_logs(self, container, since=None, verbose=True):
         """
         Returns logs from a given container.
@@ -320,7 +296,6 @@ class AutopilotPatternTest(unittest.TestCase):
         output = self.docker(*args, verbose=verbose)
         return output
 
-    @debug
     def docker_inspect(self, container):
         """
         Runs `docker inspect` on a given container and parses the JSON.
@@ -329,7 +304,6 @@ class AutopilotPatternTest(unittest.TestCase):
         output = self.docker('inspect', name)
         return json.loads(output)
 
-    @debug
     def get_service_ips(self, service):
         """
         Asks the service a list of IPs for that service by checking each
@@ -356,12 +330,10 @@ class AutopilotPatternTest(unittest.TestCase):
 
         return public, private
 
-    @debug
     def watch_docker_logs(self, name, val, timeout=60):
         """ TODO """
         pass
 
-    @debug
     def wait_for_containers(self, timeout=30):
         """
         Waits for all containers to be marked as 'Up' for all services.
@@ -376,7 +348,6 @@ class AutopilotPatternTest(unittest.TestCase):
         else:
             raise WaitTimeoutError("Timed out waiting for containers to start.")
 
-    @debug
     def wait_for_service(self, service_name, count=0, timeout=30):
         """
         Polls Consul for the service to become healthy, and optionally
@@ -397,7 +368,6 @@ class AutopilotPatternTest(unittest.TestCase):
                                    .format(service_name))
         return nodes
 
-    @debug
     def get_consul_key(self, key):
         """
         Return the Value field for a given Consul key. Handles None
@@ -408,7 +378,6 @@ class AutopilotPatternTest(unittest.TestCase):
             return result[1]['Value']
         return None
 
-    @debug
     def get_service_addresses_from_consul(self, service_name):
         """
         Asks Consul for a list of addresses for a service (compare to
@@ -420,7 +389,6 @@ class AutopilotPatternTest(unittest.TestCase):
             return ips
         return []
 
-    @debug
     def is_check_passing(self, key):
         """
         Queries consul for whether a check is passing.
@@ -434,7 +402,6 @@ class AutopilotPatternTest(unittest.TestCase):
         """ TODO """
         pass
 
-    @debug
     def wait_for_service_removed(self, service_name, timeout=30):
         """
         Polls Consul for the service to be removed.

--- a/testcases.py
+++ b/testcases.py
@@ -142,11 +142,13 @@ class AutopilotPatternTest(unittest.TestCase):
         print('{}\n{}\n{}'.format(_bar, self.id().lstrip('__main__.'), _bar))
         _report.info('', extra=dict(elapsed='elapsed', task='task'))
         for cmd in self.instrumented_commands:
-            task = " ".join([arg[:30] for arg in cmd[1][0]])
-            if cmd[0] != 'check_output':
+            if cmd[0] == 'check_output':
+                task = " ".join([str(arg)[:30] for arg in cmd[1][0]])
+            else:
                 # we don't want check_output to appear for our external
                 # calls to docker and docker-compose, but if a subclass
                 # instruments a function we want to catch that name
+                task = " ".join([str(arg)[:30] for arg in cmd[1]])
                 task = '{}: {}'.format(cmd[0], task)
             _report.info('', extra=dict(elapsed=cmd[2], task=task))
 

--- a/testcases.py
+++ b/testcases.py
@@ -1,6 +1,6 @@
 """
 The testcases module is for use by Autopilot Pattern application tests
-to run integration tests using Docker's `compose` library as its driver.
+to run integration tests using Docker and Compose as its driver.
 """
 from __future__ import print_function
 from collections import defaultdict, namedtuple
@@ -97,27 +97,23 @@ class AutopilotPatternTest(unittest.TestCase):
         TestCases so that the caller doesn't have to worry about creating
         and tearing down containers between test runs.
         """
-        if cls is not AutopilotPatternTest and \
-           cls.setUp is not AutopilotPatternTest.setUp:
-            child_setUp = cls.setUp
-            def setUp_override(self, *args, **kwargs):
-                val = child_setUp(self, *args, **kwargs)
-                AutopilotPatternTest.setUp(self)
-                return val
-            cls.setUp = setUp_override
+        child_setUp = cls.setUp
+        def setUp_override(self, *args, **kwargs):
+            val = child_setUp(self, *args, **kwargs)
+            AutopilotPatternTest._setUp(self)
+            return val
+        cls.setUp = setUp_override
 
-        if cls is not AutopilotPatternTest and \
-           cls.tearDown is not AutopilotPatternTest.tearDown:
-            child_tearDown = cls.tearDown
-            def tearDown_override(self, *args, **kwargs):
-                AutopilotPatternTest.tearDown(self)
-                return child_tearDown(self, *args, **kwargs)
-            cls.tearDown = tearDown_override
+        child_tearDown = cls.tearDown
+        def tearDown_override(self, *args, **kwargs):
+            AutopilotPatternTest._tearDown(self)
+            return child_tearDown(self, *args, **kwargs)
+        cls.tearDown = tearDown_override
 
     @debug
-    def setUp(self):
+    def _setUp(self):
         """
-        AutopilotPatternTest.setUp will be called after a subclass's
+        AutopilotPatternTest._setUp will be called after a subclass's
         own setUp. Starts the containers and waits for them all to be
         marked with Status 'Up'
         """
@@ -126,9 +122,9 @@ class AutopilotPatternTest(unittest.TestCase):
         self.wait_for_containers()
 
     @debug
-    def tearDown(self):
+    def _tearDown(self):
         """
-        AutopilotPatternTest.setUp will be called before a subclass's
+        AutopilotPatternTest._tearDown will be called before a subclass's
         own tearDown. Stops all the containers.
         """
         self.compose('stop')


### PR DESCRIPTION
@misterbisson this is a big bunch of changes that'll have us using `docker-compose` and `docker` directly, rather than using the Remote API.

Previously we were using the Python Docker client library, dockerpty-py, and the compose library in the test rig because these give us a little bit more "direct" API access. But in addition to these being not very
good libraries, it fails us from a testing standpoint. We don't _want_ to test the Remote API (which is presumably well-tested by our core engineering team), we want to test using the actual client binaries that Docker, Inc. provides.

So instead of using these libs to make API calls as we were, this PR makes `subprocess.Popen` calls to Docker or Compose. A nice added advantage is that we'll be able to test against multiple versions of the client in parallel if we want, and that it's easier to instrument the client calls. This lets us have a test output that looks like this:

```
----------------------------------------------------------------------
WorkshopStackTest.test_scaleup_scaledown
----------------------------------------------------------------------
elapsed         | task
1.59338212013   | docker-compose -f docker-compose.yml -p workshop up -d
0.244590044022  | docker-compose -f docker-compose.yml -p workshop ps
0.059956073761  | docker inspect workshop_consul_1
0.112968921661  | docker exec workshop_nginx_1 cat /etc/nginx/nginx.conf
0.135507106781  | docker exec workshop_nginx_1 cat /etc/nginx/nginx.conf
0.876389026642  | docker-compose -f docker-compose.yml -p workshop scale sales=3
0.134047031403  | docker exec workshop_nginx_1 cat /etc/nginx/nginx.conf
0.136224031448  | docker exec workshop_nginx_1 cat /etc/nginx/nginx.conf
0.152096986771  | docker exec workshop_nginx_1 cat /etc/nginx/nginx.conf
0.146039009094  | docker exec workshop_nginx_1 cat /etc/nginx/nginx.conf
0.293953895569  | docker-compose -f docker-compose.yml -p workshop ps -q sales
0.149887084961  | docker exec 144d544563041a0893a7634eafe3a3 ip -o addr
0.151185035706  | docker exec 2cbac1b0b815762476af825c417b90 ip -o addr
0.140347003937  | docker exec 3dc7e2d2f3ee225815a8decb07ae65 ip -o addr
0.625655889511  | docker-compose -f docker-compose.yml -p workshop scale sales=2
0.12455701828   | docker exec workshop_nginx_1 cat /etc/nginx/nginx.conf
0.139688014984  | docker exec workshop_nginx_1 cat /etc/nginx/nginx.conf
0.154396057129  | docker exec workshop_nginx_1 cat /etc/nginx/nginx.conf
0.234007120132  | docker-compose -f docker-compose.yml -p workshop ps -q sales
0.110437870026  | docker exec 144d544563041a0893a7634eafe3a3 ip -o addr
0.0947268009186 | docker exec 2cbac1b0b815762476af825c417b90 ip -o addr
1.67618107796   | docker-compose -f docker-compose.yml -p workshop stop
0.260026931763  | docker-compose -f docker-compose.yml -p workshop rm -f
.
----------------------------------------------------------------------
Ran 1 test in 37.142s

OK
```
